### PR TITLE
optional 'autofocus' argument in constructor and mount-function 

### DIFF
--- a/src/controller/MoleculeEditor.ts
+++ b/src/controller/MoleculeEditor.ts
@@ -46,7 +46,7 @@ class MoleculeEditor {
     panning: boolean;
     _viewport_offset: Coords;
     graph_group: Konva.Group;
-    constructor(stage: Konva.Stage) {
+    constructor(stage: Konva.Stage, autofocus: boolean = true) {
         this.stage = stage;
         this.stylesheet = new Stylesheet();
         this.graph = new Graph();
@@ -80,7 +80,7 @@ class MoleculeEditor {
         container.addEventListener("keydown", (e) => { e.preventDefault(); this.on_keydown(e); });
         container.addEventListener("keyup", (e) => { e.preventDefault(); this.on_keyup(e); });
         container.tabIndex = 1;
-        container.focus();
+        autofocus && container.focus();
         this.stage.add(this.background_layer);
         this.stage.add(this.drawing_layer);
         this.stage.add(this.top_layer);
@@ -93,13 +93,13 @@ class MoleculeEditor {
         this._viewport_offset = {x: 0, y: 0};
     }
 
-    static from_html_element(el: HTMLDivElement) {
+    static from_html_element(el: HTMLDivElement, autofocus: boolean = true) {
         const stage = new Konva.Stage({
             container: el,
             width: el.clientWidth,
             height: el.clientHeight
         });
-        return new MoleculeEditor(stage);
+        return new MoleculeEditor(stage, autofocus);
     }
 
     commit_action(action: Action) {


### PR DESCRIPTION
added an optional argument to the molecular-editor constructor and from_html_element function to control autofocus upon editor mount
форматирование решил не делать, первая половина имени ветки неактуальна, не мой огород, не буду свои порядки наводить :))