### PR TITLE
fix: expose css styles

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -16,7 +16,8 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
-    }
+    },
+    "./style.css": "./dist/vue.css"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Из-за того, что пакет не экспоузит стили, потребитель не может их импортировать из пакета и адекватно использовать компонент